### PR TITLE
Upgrade elm packages for benchmarks

### DIFF
--- a/benchmark/elm.json
+++ b/benchmark/elm.json
@@ -9,19 +9,19 @@
         "direct": {
             "BrianHicks/elm-trend": "2.1.3",
             "elm/browser": "1.0.2",
-            "elm/core": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
-            "elm-explorations/benchmark": "1.0.1",
+            "elm/virtual-dom": "1.0.3",
+            "elm-explorations/benchmark": "1.0.2",
             "elm-explorations/linear-algebra": "1.0.3"
         },
         "indirect": {
-            "Skinney/murmur3": "2.0.8",
             "elm/json": "1.1.3",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "mdgriffith/style-elements": "5.0.1"
+            "mdgriffith/style-elements": "5.0.2",
+            "robinheghan/murmur3": "1.0.0"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
Upgrade the packages since they don't work anymore with the old versions.

This is because the old indirect dependency `Skinney/murmur3` of `elm-explorations/benchmark` doesn't exist anymore. Instead, they use `robinheghan/murmur3` now.